### PR TITLE
Multithread texture loading

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ find_package(Stb REQUIRED)
 find_package(spdlog CONFIG REQUIRED)
 find_package(fmt CONFIG REQUIRED)
 find_package(unofficial-concurrentqueue CONFIG REQUIRED)
+find_package(Ktx CONFIG REQUIRED)
 target_include_directories(VkTestSite PRIVATE
         ${Stb_INCLUDE_DIR}
 )
@@ -78,6 +79,7 @@ target_link_libraries(VkTestSite PRIVATE
         spdlog::spdlog
         fmt::fmt
         unofficial::concurrentqueue::concurrentqueue
+        KTX::ktx
 )
 target_compile_definitions(VkTestSite PRIVATE
         VULKAN_HPP_DISPATCH_LOADER_DYNAMIC=1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ add_executable(VkTestSite src/main.cpp
         src/Pipeline.h
         src/Light.h
         src/TracyLogSink.h
+        src/StagingBuffer.h
 )
 
 find_package(glfw3 CONFIG REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ add_executable(VkTestSite src/main.cpp
         src/Light.h
         src/TracyLogSink.h
         src/StagingBuffer.h
+        src/TransferThread.h
 )
 
 find_package(glfw3 CONFIG REQUIRED)
@@ -58,6 +59,7 @@ find_package(tinyfiledialogs CONFIG REQUIRED)
 find_package(Stb REQUIRED)
 find_package(spdlog CONFIG REQUIRED)
 find_package(fmt CONFIG REQUIRED)
+find_package(unofficial-concurrentqueue CONFIG REQUIRED)
 target_include_directories(VkTestSite PRIVATE
         ${Stb_INCLUDE_DIR}
 )
@@ -74,6 +76,7 @@ target_link_libraries(VkTestSite PRIVATE
         tinyfiledialogs::tinyfiledialogs
         spdlog::spdlog
         fmt::fmt
+        unofficial::concurrentqueue::concurrentqueue
 )
 target_compile_definitions(VkTestSite PRIVATE
         VULKAN_HPP_DISPATCH_LOADER_DYNAMIC=1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ add_executable(VkTestSite src/main.cpp
         src/TracyLogSink.h
         src/StagingBuffer.h
         src/TransferThread.h
+        src/TextureWorkersPool.h
 )
 
 find_package(glfw3 CONFIG REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.27)
 
 include(CMake/Vcpkg.cmake)
 set(VCPKG_TARGET_TRIPLET x64-windows)
+set(VCPKG_OVERLAY_PORTS "${CMAKE_SOURCE_DIR}/vcpkg-overlays/ports")
 
 project(VkTestSite)
 

--- a/src/BufferUtils.cpp
+++ b/src/BufferUtils.cpp
@@ -4,8 +4,6 @@
 #include "vulkan-memory-allocator-hpp/vk_mem_alloc.hpp"
 #include "utils.cpp"
 
-#include <iostream>
-#include <optional>
 #include <ranges>
 #include <vector>
 

--- a/src/BufferUtils.cpp
+++ b/src/BufferUtils.cpp
@@ -80,6 +80,7 @@ static void copyBuffer(
   const vk::Buffer dstBuffer,
   const vk::DeviceSize size
 ) {
+  ZoneScoped;
   executeSingleTimeCommands(device, graphicsQueue, commandPool, [&](const vk::CommandBuffer cmd) {
     const auto region = vk::BufferCopy({}, {}, size);
     cmd.copyBuffer(srcBuffer, dstBuffer, region);
@@ -95,6 +96,7 @@ static void copyBufferToImage(
   const uint32_t width,
   const uint32_t height
 ) {
+  ZoneScoped;
   executeSingleTimeCommands(device, graphicsQueue, commandPool, [&](const vk::CommandBuffer cmd) {
     constexpr auto subresource = vk::ImageSubresourceLayers(vk::ImageAspectFlagBits::eColor, 0, 0, 1);
     const auto region = vk::BufferImageCopy(

--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -43,9 +43,10 @@ Model::Model(
   const vk::Queue graphicsQueue,
   const vk::CommandPool commandPool,
   vma::Allocator allocator,
-  TextureManager& textureManager,
+  TextureManager &textureManager,
   const std::filesystem::path &modelPath
 ) {
+  ZoneScoped;
   std::cout << "Loading model from: " << modelPath.string() << std::endl;
   Assimp::Importer importer;
 
@@ -72,6 +73,7 @@ void Model::createMesh(
   vma::Allocator allocator,
   const aiScene *scene
 ) {
+  ZoneScoped;
   std::vector<Vertex> vertices = {};
   std::vector<uint32_t> indices = {};
 
@@ -90,7 +92,9 @@ void Model::processNode(
   const aiScene *scene,
   const glm::mat4 &parentTransform,
   std::vector<Vertex> &vertices,
-  std::vector<uint32_t> &indices) {
+  std::vector<uint32_t> &indices
+) {
+  ZoneScoped;
   auto transform = parentTransform * aiMatrix4x4ToGlm(node->mTransformation);
 
   for (unsigned int m = 0; m < node->mNumMeshes; ++m) {
@@ -141,10 +145,11 @@ void Model::processNode(
 }
 
 void Model::processMaterials(
-  TextureManager& textureManager,
+  TextureManager &textureManager,
   const aiScene *scene,
   const std::filesystem::path &modelParent
 ) {
+  ZoneScoped;
   const auto absoluteModelParent = std::filesystem::canonical(modelParent);
 
   for (unsigned int matIdx = 0; matIdx < scene->mNumMaterials; ++matIdx) {
@@ -162,6 +167,7 @@ void Model::createCommandBuffers(
   const vk::CommandPool commandPool,
   const uint32_t imagesCount
 ) {
+  ZoneScoped;
   const auto info = vk::CommandBufferAllocateInfo(
     commandPool, vk::CommandBufferLevel::eSecondary, imagesCount
   );
@@ -184,6 +190,7 @@ vk::CommandBuffer Model::cmdDraw(
   const uint32_t subpass,
   const uint32_t imageIndex
 ) {
+  ZoneScoped;
   const auto inheritanceInfo = vk::CommandBufferInheritanceInfo(renderPass, subpass, framebuffer);
   const auto beginInfo = vk::CommandBufferBeginInfo(
     vk::CommandBufferUsageFlagBits::eRenderPassContinue | vk::CommandBufferUsageFlagBits::eSimultaneousUse,
@@ -194,9 +201,7 @@ vk::CommandBuffer Model::cmdDraw(
   const auto push_consts = calcPushConsts();
 
   cmdBuf.reset();
-  cmdBuf.begin(beginInfo);
-
-  {
+  cmdBuf.begin(beginInfo); {
     TracyVkZone(&tracyCtx, cmdBuf, "Geometry");
     swapchain.cmdSetViewport(cmdBuf);
     swapchain.cmdSetScissor(cmdBuf);

--- a/src/StagingBuffer.h
+++ b/src/StagingBuffer.h
@@ -1,0 +1,219 @@
+#pragma once
+
+#ifndef STAGINGBUFF_H
+#define STAGINGBUFF_H
+
+#include <vulkan/vulkan.hpp>
+#include "vulkan-memory-allocator-hpp/vk_mem_alloc.hpp"
+
+#include "BufferUtils.cpp"
+
+/**
+ * @brief StagingBuffer providing a CPU-accessible buffer for
+ * uploading GPU resources (vertex/index buffers, textures, etc.)
+ *
+ * Manages allocations within a single large host-visible buffer using
+ * a VMA virtual block, supporting multiple in-flight GPU transfers simultaneously
+ *
+ * Allocation lifecycle:
+ * 1. Call <code>StagingBuffer::tryAllocate</code> or
+ * <code>StagingBuffer::allocateBlocking</code>
+ * to reserve a contiguous region of the staging buffer
+ * 2. Write a CPU-side data directly into the mapped pointer returned
+ * in <code>StagingAllocation.mapped</code>
+ * 3. Record a Vulkan copy command (buffer -> buffer or buffer -> image)
+ * 4. Call <code>StagingBuffer::trackAlloc</code> to mark the allocation
+ * as "in-flight" and associate it with the next timeline value
+ * 5. After GPU work completes, <code>StagingBuffer::pollReclaimed</code>
+ * free the allocation for reuse
+ */
+class StagingBuffer {
+public:
+  struct StagingAllocation {
+    vk::DeviceSize size = 0;
+    vk::DeviceSize offset = 0;
+    vma::VirtualAllocation handle = nullptr;
+    void *mapped = nullptr;
+    uint64_t timelineValue = 0;
+  };
+
+  StagingBuffer(
+    const vk::Device device,
+    const vma::Allocator allocator,
+    const vk::DeviceSize bufferSize
+  ): m_device(device), m_allocator(allocator), m_bufferSize(bufferSize) {
+    ZoneScoped;
+    std::tie(m_buffer, m_bufferAlloc) = createBufferUnique(
+      allocator,
+      bufferSize,
+      vk::BufferUsageFlagBits::eTransferSrc,
+      vma::MemoryUsage::eAuto,
+      vma::AllocationCreateFlagBits::eMapped | vma::AllocationCreateFlagBits::eHostAccessSequentialWrite
+    );
+
+    m_mapped = allocator.mapMemory(m_bufferAlloc.get());
+    if (!m_mapped) throw std::runtime_error("Failed to map staging memory");
+
+    m_virtualBlock = vma::createVirtualBlockUnique(vma::VirtualBlockCreateInfo(bufferSize));
+    m_timeline = m_device.createSemaphoreUnique(vk::SemaphoreCreateInfo());
+  }
+
+  ~StagingBuffer() {
+    ZoneScoped;
+    std::scoped_lock lock(m_mutex);
+    m_device.waitIdle();
+
+    for (const auto &alloc: m_pending) {
+      TracySecureFree(alloc.mapped);
+      m_virtualBlock->virtualFree(alloc.handle);
+    }
+    m_pending.clear();
+    for (const auto &alloc: m_transferring) {
+      TracySecureFree(alloc.mapped);
+      m_virtualBlock->virtualFree(alloc.handle);
+    }
+    m_transferring.clear();
+
+    if (m_mapped) {
+      m_allocator.unmapMemory(m_bufferAlloc.get());
+      m_mapped = nullptr;
+    }
+  }
+
+  /**
+   * Attempt to allocate space from the staging buffer without blocking
+   * @param size Number of bytes to allocate
+   * @param alignment Alignment in bytes. Defaults sets to 256
+   * @return Optional<StagingAllocation>. Returns a valid allocation if space was available immediately; returns std::nullopt if no space could be reserved at the moment
+   */
+  std::optional<StagingAllocation> tryAllocate(const vk::DeviceSize size, const vk::DeviceSize alignment = 256) {
+    ZoneScoped;
+    if (size > m_bufferSize)
+      throw std::runtime_error("Try to allocate size > staging buffer size");
+
+    const auto vci = vma::VirtualAllocationCreateInfo(size, alignment);
+    vma::VirtualAllocation virtualAlloc = nullptr;
+    vk::DeviceSize offset = 0;
+    std::lock_guard lock(m_mutex);
+    if (const auto result = m_virtualBlock->virtualAllocate(&vci, &virtualAlloc, &offset);
+      result != vk::Result::eSuccess) {
+      return std::nullopt;
+    }
+
+    const auto mappedPtr = static_cast<char *>(m_mapped) + offset;
+    TracySecureAllocN(mappedPtr, size, "Staging buffer allocations");
+
+    StagingAllocation allocation;
+    allocation.size = size;
+    allocation.handle = virtualAlloc;
+    allocation.offset = offset;
+    allocation.mapped = mappedPtr;
+    m_pending.push_back(allocation);
+    return allocation;
+  }
+
+  /**
+   * @brief Attempt to allocate space from the staging buffer blocking until success
+   * @param size Number of bytes to allocate
+   * @param alignment Alignment in bytes. Defaults sets to 256
+   * @return StagingAllocation. Guaranteed to succeed eventually, unless the requested size exceeds the total staging buffer capacity
+   *
+   * Behavior:
+   *  - If space is available now, returns immediately.
+   *  - If not, determines the oldest in-flight allocation (tracked with a
+   *    timeline semaphore), and blocks the calling CPU thread using
+   *    vk::Device::waitSemaphores until the GPU has completed that work.
+   *  - Once GPU has signaled, freed ranges are reclaimed and allocation is retried.
+   */
+  StagingAllocation allocateBlocking(const vk::DeviceSize size, const vk::DeviceSize alignment = 256) {
+    ZoneScoped;
+    while (true) {
+      if (const auto alloc = tryAllocate(size, alignment)) {
+        return *alloc;
+      }
+
+      uint64_t waitValue = 0; {
+        std::unique_lock lock(m_mutex);
+        if (!m_transferring.empty()) {
+          waitValue = m_transferring.front().timelineValue;
+          for (const auto &alloc: m_transferring) {
+            waitValue = std::min(waitValue, alloc.timelineValue);
+          }
+        }
+      }
+
+      if (waitValue > 0) {
+        const auto waitInfo = vk::SemaphoreWaitInfo({}, m_timeline.get(), waitValue);
+        auto _ = m_device.waitSemaphores(waitInfo, UINT64_MAX);
+        pollReclaimed();
+      } else {
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+      }
+    }
+  }
+
+  /**
+   * Starting tracking allocation
+   * @remark Must be called after Queue submit with allocation semaphore value
+   * @param alloc staging allocation
+   */
+  void trackAlloc(StagingAllocation &alloc) {
+    ZoneScoped;
+    std::lock_guard lock(m_mutex);
+
+    const auto it = std::ranges::find_if(
+      m_pending, [&](const StagingAllocation &a) { return a.handle == alloc.handle; });
+    if (it == m_pending.end()) {
+      throw std::runtime_error("Tried to track allocation does not exist");
+    }
+
+    const auto value = ++m_nextTimelineValue;
+    alloc.timelineValue = value;
+    m_transferring.push_back(alloc);
+    m_pending.erase(it);
+  }
+
+  /**
+   * Reclaim staging buffer ranges whose GPU transfers have competed
+   */
+  void pollReclaimed() {
+    ZoneScoped;
+    std::lock_guard lock(m_mutex);
+    const auto completed = m_device.getSemaphoreCounterValue(m_timeline.get());
+
+    for (int i = 0; i < m_transferring.size();) {
+      if (m_transferring[i].timelineValue <= completed) {
+        TracyFree(m_transferring[i].mapped);
+        m_virtualBlock->virtualFree(m_transferring[i].handle);
+        m_transferring.erase(m_transferring.begin() + i);
+      } else {
+        ++i;
+      }
+    }
+  }
+
+  [[nodiscard]] vk::SemaphoreSubmitInfo makeSignalInfo() const {
+    return {m_timeline.get(), m_nextTimelineValue, vk::PipelineStageFlagBits2::eAllCommands};
+  }
+
+  [[nodiscard]] vk::Buffer getBuffer() const { return m_buffer.get(); }
+
+private:
+  const vk::Device m_device = nullptr;
+  const vma::Allocator m_allocator = nullptr;
+  const vk::DeviceSize m_bufferSize = 0;
+
+  vma::UniqueBuffer m_buffer;
+  vma::UniqueAllocation m_bufferAlloc;
+  vma::UniqueVirtualBlock m_virtualBlock;
+  void *m_mapped = nullptr;
+
+  TracyLockableN(std::mutex, m_mutex, "Staging Buffer Mutex");
+  std::vector<StagingAllocation> m_pending;
+  std::vector<StagingAllocation> m_transferring;
+
+  vk::UniqueSemaphore m_timeline;
+  uint64_t m_nextTimelineValue = 0;
+};
+
+#endif //STAGINGBUFF_H

--- a/src/Texture.h
+++ b/src/Texture.h
@@ -73,6 +73,7 @@ inline Texture::Texture(
   const bool useSampler,
   const std::string &name
 ): width(width), height(height), mipLevels(mipLevels) {
+  ZoneScoped;
   std::tie(m_image, m_imageAlloc) = createImageUnique(
     allocator,
     width, height, mipLevels,
@@ -105,6 +106,7 @@ inline std::unique_ptr<Texture> Texture::createFromFile(
   const std::filesystem::path &path,
   const vk::Format format
 ) {
+  ZoneScoped;
   int width, height, channels;
   stbi_uc *origPixels = stbi_load(
     path.string().c_str(),

--- a/src/TextureManager.cpp
+++ b/src/TextureManager.cpp
@@ -21,7 +21,7 @@ uint32_t TextureManager::loadTextureFromFile(
   const auto texturePath = textureParent / filename;
 
   if (const auto it = m_cache.find(filename.string()); it != m_cache.end()) {
-    std::cout << std::format("Reuse texture {} from {}", filename.string(), it->second) << "\n";
+    spdlog::info(std::format("Reuse texture {} from {}", filename.string(), it->second));
     return it->second;
   }
 
@@ -31,7 +31,7 @@ uint32_t TextureManager::loadTextureFromFile(
       break;
     }
   }
-  std::cout << std::format("Push texture loading job: file {} at slot {}", filename.string(), slot) << "\n";
+  spdlog::info(std::format("Push texture loading job: file {} at slot {}", filename.string(), slot));
 
   if (slot >= MAX_TEXTURE_PER_DESCRIPTOR) {
     throw std::runtime_error(

--- a/src/TextureManager.cpp
+++ b/src/TextureManager.cpp
@@ -4,10 +4,12 @@ TextureManager::TextureManager(
   const vk::Device device,
   const vk::Queue graphicsQueue,
   const vk::CommandPool commandPool,
+  StagingBuffer &stagingBuffer,
+  TransferThread &transferThread,
   const vma::Allocator allocator,
   DescriptorSet &descriptorSet,
   const uint32_t shaderBinding
-): m_device(device), m_graphicsQueue(graphicsQueue), m_commandPool(commandPool),
+): m_device(device), m_graphicsQueue(graphicsQueue), m_commandPool(commandPool), m_stagingBuffer(&stagingBuffer), m_transferThread(&transferThread),
    m_allocator(allocator), m_descriptorSet(&descriptorSet), m_shaderBinding(shaderBinding) {
   m_sampler = createSamplerUnique(device);
 }
@@ -41,13 +43,13 @@ uint32_t TextureManager::loadTextureFromFile(
   auto texture = Texture::createFromFile(
     m_device,
     m_allocator,
-    m_graphicsQueue,
-    m_commandPool,
+    *m_stagingBuffer,
+    *m_transferThread,
     texturePath,
     format
   );
 
-  generateMipmaps(
+  /*generateMipmaps(
     m_device,
     m_graphicsQueue,
     m_commandPool,
@@ -55,7 +57,7 @@ uint32_t TextureManager::loadTextureFromFile(
     texture->width,
     texture->height,
     texture->mipLevels
-  );
+  );*/
 
   m_textures[slot] = std::move(texture);
   m_cache[filename.string()] = slot;

--- a/src/TextureManager.cpp
+++ b/src/TextureManager.cpp
@@ -17,6 +17,7 @@ uint32_t TextureManager::loadTextureFromFile(
   const std::filesystem::path &filename,
   const vk::Format format
 ) {
+  ZoneScoped;
   const auto texturePath = textureParent / filename;
 
   if (const auto it = m_cache.find(filename.string()); it != m_cache.end()) {

--- a/src/TextureManager.h
+++ b/src/TextureManager.h
@@ -2,6 +2,7 @@
 #define TEXTUREMANAGER_H
 
 #include "DescriptorSet.h"
+#include "TextureWorkersPool.h"
 #include "Swapchain.h"
 #include "Texture.h"
 #include "utils.cpp"
@@ -12,9 +13,7 @@ public:
     vk::Device device,
     vk::Queue graphicsQueue,
     vk::CommandPool commandPool,
-    StagingBuffer &stagingBuffer,
-    TransferThread &transferThread,
-    vma::Allocator allocator,
+    TextureWorkerPool &workerPool,
     DescriptorSet &descriptorSet,
     uint32_t shaderBinding
   );
@@ -27,6 +26,8 @@ public:
     vk::Format format = vk::Format::eR8G8B8A8Unorm
   );
 
+  void checkTextureLoading();
+
   void updateDS(DescriptorSet& descriptorSet);
 
   std::optional<Texture *> getTexture(uint32_t slot);
@@ -38,11 +39,8 @@ private:
   vk::Device m_device = nullptr;
   vk::Queue m_graphicsQueue = nullptr;
   vk::CommandPool m_commandPool = nullptr;
-  vma::Allocator m_allocator = nullptr;
   DescriptorSet *m_descriptorSet = nullptr;
-  StagingBuffer *m_stagingBuffer = nullptr;
-  TransferThread *m_transferThread = nullptr;
-
+  TextureWorkerPool *m_workerPool = nullptr;
   uint32_t m_shaderBinding = 0;
 
   std::unordered_map<std::string, uint32_t> m_cache = {};

--- a/src/TextureManager.h
+++ b/src/TextureManager.h
@@ -12,6 +12,8 @@ public:
     vk::Device device,
     vk::Queue graphicsQueue,
     vk::CommandPool commandPool,
+    StagingBuffer &stagingBuffer,
+    TransferThread &transferThread,
     vma::Allocator allocator,
     DescriptorSet &descriptorSet,
     uint32_t shaderBinding
@@ -38,6 +40,8 @@ private:
   vk::CommandPool m_commandPool = nullptr;
   vma::Allocator m_allocator = nullptr;
   DescriptorSet *m_descriptorSet = nullptr;
+  StagingBuffer *m_stagingBuffer = nullptr;
+  TransferThread *m_transferThread = nullptr;
 
   uint32_t m_shaderBinding = 0;
 

--- a/src/TextureWorkersPool.h
+++ b/src/TextureWorkersPool.h
@@ -1,0 +1,177 @@
+#ifndef TEXTUREWORKERSPOOL_H
+#define TEXTUREWORKERSPOOL_H
+
+#include <vulkan/vulkan.hpp>
+#include "concurrentqueue/blockingconcurrentqueue.h"
+#include "concurrentqueue/concurrentqueue.h"
+#include <stb_image.h>
+
+#include "StagingBuffer.h"
+#include "TransferThread.h"
+#include "Texture.h"
+#include <filesystem>
+
+struct TextureLoadJob {
+  uint32_t texIndex;
+  std::filesystem::path filepath;
+};
+
+struct TextureLoadDone {
+  TextureLoadJob job;
+  std::unique_ptr<Texture> texture;
+};
+
+class TextureWorkerPool {
+public:
+  TextureWorkerPool(
+    const vk::Device device,
+    const vma::Allocator allocator,
+    StagingBuffer &stagingBuffer,
+    TransferThread &transferThread,
+    const uint32_t threadCount = std::thread::hardware_concurrency() - 2
+  ) : m_device(device), m_allocator(allocator),
+      m_stagingBuffer(stagingBuffer), m_transferThread(transferThread) {
+    ZoneScoped;
+    for (int i = 0; i < threadCount; ++i) {
+      m_threads.emplace_back([this, i]() { threadLoop(i); });
+    }
+  }
+
+  ~TextureWorkerPool() {
+    m_stop = true;
+    for (auto &tread: m_threads) {
+      if (tread.joinable())
+        tread.join();
+    }
+  }
+
+  TextureWorkerPool(const TextureWorkerPool &) = delete;
+
+  TextureWorkerPool &operator=(const TextureWorkerPool &) = delete;
+
+  void pushJob(const TextureLoadJob &job) {
+    ZoneScoped;
+    m_queue.enqueue(job);
+  }
+
+  bool tryDequeueDone(TextureLoadDone &done) {
+    return m_doneQueue.try_dequeue(done);
+  }
+
+private:
+  vk::Device m_device = nullptr;
+  vma::Allocator m_allocator = nullptr;
+  StagingBuffer &m_stagingBuffer;
+  TransferThread &m_transferThread;
+
+  std::atomic_bool m_stop;
+  std::vector<std::thread> m_threads = {};
+  moodycamel::BlockingConcurrentQueue<TextureLoadJob> m_queue;
+  moodycamel::ConcurrentQueue<TextureLoadDone> m_doneQueue;
+
+  void threadLoop(const uint32_t threadIdx) {
+    tracy::SetThreadNameWithHint(std::format("Texture Worker {}", threadIdx).c_str(), UINT8_MAX);
+    while (!m_stop) {
+      TextureLoadJob job{};
+      m_queue.wait_dequeue(job); {
+        ZoneScoped;
+        if (!job.filepath.has_extension())
+          throw std::invalid_argument("Job filepath must be contains file extension");
+
+        if (job.filepath.extension() == ".ktx" || job.filepath.extension() == ".ktx2") {
+          auto texture = loadKtxTexture(job);
+          m_doneQueue.enqueue({
+            .job = job,
+            .texture = std::move(texture)
+          });
+        } else {
+          auto texture = loadGenericTexture(job);
+          m_doneQueue.enqueue({
+            .job = job,
+            .texture = std::move(texture)
+          });
+        }
+      }
+    }
+  }
+
+  std::unique_ptr<Texture> loadGenericTexture(const TextureLoadJob &job) {
+    ZoneScoped;
+    int width, height, channels;
+    stbi_uc *origPixels;
+    {
+      ZoneScopedN("Texture Loading");
+      origPixels = stbi_load(
+        job.filepath.string().c_str(),
+        &width,
+        &height,
+        &channels,
+        0
+      );
+      if (!origPixels) {
+        throw std::runtime_error("Failed to load texture image: " + job.filepath.string());
+      }
+    }
+
+    const vk::DeviceSize targetSize = width * height * 4;
+    const vk::DeviceSize originalSize = width * height * channels;
+    auto mipLevels = static_cast<uint32_t>(
+      std::floor(std::log2(std::max(width, height))) + 1
+    );
+
+    auto texture = std::make_unique<Texture>(
+      m_device, m_allocator,
+      width, height, mipLevels,
+      vk::Format::eR8G8B8A8Unorm,
+      vk::SampleCountFlagBits::e1,
+      vk::ImageAspectFlagBits::eColor,
+      vk::ImageUsageFlagBits::eSampled
+      | vk::ImageUsageFlagBits::eTransferSrc | vk::ImageUsageFlagBits::eTransferDst,
+      true,
+      job.filepath.string()
+    );
+
+    auto alloc = m_stagingBuffer.allocateBlocking(targetSize); {
+      ZoneScopedN("Staging texture data copy");
+      //memcpy(alloc.mapped, pixels.data(), pixels.size());
+      auto* mappedBytes = static_cast<std::uint8_t*>(alloc.mapped);
+
+      if (channels == 4) {
+        memcpy(alloc.mapped, origPixels, originalSize);
+      } else if (channels == 3) {
+        for (int i = 0; i < width * height; ++i) {
+          mappedBytes[i * 4 + 0] = origPixels[i * 3 + 0];
+          mappedBytes[i * 4 + 1] = origPixels[i * 3 + 1];
+          mappedBytes[i * 4 + 2] = origPixels[i * 3 + 2];
+          mappedBytes[i * 4 + 3] = 255;
+        }
+      }
+    }
+
+    {
+      ZoneScopedN("Free stbi ptr");
+      stbi_image_free(origPixels);
+    }
+
+    constexpr auto subresource = vk::ImageSubresourceLayers(vk::ImageAspectFlagBits::eColor, 0, 0, 1);
+    const TextureUploadJob copyJob{
+      .allocation = alloc,
+      .dstImage = texture->getImage(),
+      .subresourceRange = vk::ImageSubresourceRange(
+        vk::ImageAspectFlagBits::eColor, 0, mipLevels, 0, 1),
+      .region = vk::BufferImageCopy(
+        alloc.offset, 0, 0, subresource,
+        vk::Offset3D(0, 0, 0),
+        vk::Extent3D(width, height, 1)),
+    };
+    m_transferThread.pushJob(copyJob);
+
+    return texture;
+  }
+
+  std::unique_ptr<Texture> loadKtxTexture(const TextureLoadJob &job) {
+    return nullptr;
+  }
+};
+
+#endif //TEXTUREWORKERSPOOL_H

--- a/src/TextureWorkersPool.h
+++ b/src/TextureWorkersPool.h
@@ -6,6 +6,9 @@
 #include "concurrentqueue/concurrentqueue.h"
 #include <stb_image.h>
 
+#include <ktx.h>
+#include <ktxvulkan.h>
+
 #include "StagingBuffer.h"
 #include "TransferThread.h"
 #include "Texture.h"
@@ -98,8 +101,7 @@ private:
   std::unique_ptr<Texture> loadGenericTexture(const TextureLoadJob &job) {
     ZoneScoped;
     int width, height, channels;
-    stbi_uc *origPixels;
-    {
+    stbi_uc *origPixels; {
       ZoneScopedN("Texture Loading");
       origPixels = stbi_load(
         job.filepath.string().c_str(),
@@ -134,7 +136,7 @@ private:
     auto alloc = m_stagingBuffer.allocateBlocking(targetSize); {
       ZoneScopedN("Staging texture data copy");
       //memcpy(alloc.mapped, pixels.data(), pixels.size());
-      auto* mappedBytes = static_cast<std::uint8_t*>(alloc.mapped);
+      auto *mappedBytes = static_cast<std::uint8_t *>(alloc.mapped);
 
       if (channels == 4) {
         memcpy(alloc.mapped, origPixels, originalSize);
@@ -146,9 +148,7 @@ private:
           mappedBytes[i * 4 + 3] = 255;
         }
       }
-    }
-
-    {
+    } {
       ZoneScopedN("Free stbi ptr");
       stbi_image_free(origPixels);
     }
@@ -170,7 +170,74 @@ private:
   }
 
   std::unique_ptr<Texture> loadKtxTexture(const TextureLoadJob &job) {
-    return nullptr;
+    ZoneScoped;
+    ktxTexture2 *kTexture; {
+      ZoneScopedN("Load KTX2 Texture");
+      auto result = ktxTexture2_CreateFromNamedFile(
+        job.filepath.string().c_str(), KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT, &kTexture);
+
+      if (result != KTX_SUCCESS) {
+        throw std::runtime_error("Failed to load KTX: " + job.filepath.string());
+      }
+    }
+    if (ktxTexture2_NeedsTranscoding(kTexture)) {
+      ZoneScopedN("Transcoding");
+      auto result = ktxTexture2_TranscodeBasis(
+        kTexture,
+        KTX_TTF_BC7_RGBA,
+        0);
+      if (result != KTX_SUCCESS) {
+        ktxTexture_Destroy(ktxTexture(kTexture));
+        throw std::runtime_error("Failed to transcode KTX2 texture");
+      }
+    }
+
+    auto width = kTexture->baseWidth;
+    auto height = kTexture->baseHeight;
+    auto mipLevels = kTexture->numLevels;
+    auto texture = std::make_unique<Texture>(
+      m_device, m_allocator,
+      width, height, mipLevels,
+      static_cast<vk::Format>(kTexture->vkFormat),
+      vk::SampleCountFlagBits::e1,
+      vk::ImageAspectFlagBits::eColor,
+      vk::ImageUsageFlagBits::eSampled
+      | vk::ImageUsageFlagBits::eTransferSrc | vk::ImageUsageFlagBits::eTransferDst,
+      true,
+      job.filepath.string()
+    );
+
+    ktx_size_t offset;
+    auto result = ktxTexture_GetImageOffset(
+      ktxTexture(kTexture), 0, 0, 0, &offset
+    );
+    if (result != KTX_SUCCESS) {
+      ktxTexture_Destroy(ktxTexture(kTexture));
+      throw std::runtime_error("Failed to get KTX2 image offset");
+    }
+
+    size_t size = ktxTexture_GetImageSize(ktxTexture(kTexture), 0);
+    auto alloc = m_stagingBuffer.allocateBlocking(size); {
+      ZoneScopedN("Staging texture data copy");
+      memcpy(alloc.mapped, kTexture->pData + offset, size);
+    }
+
+    constexpr auto subresource = vk::ImageSubresourceLayers(vk::ImageAspectFlagBits::eColor, 0, 0, 1);
+    const TextureUploadJob copyJob{
+      .allocation = alloc,
+      .dstImage = texture->getImage(),
+      .subresourceRange = vk::ImageSubresourceRange(
+        vk::ImageAspectFlagBits::eColor, 0, mipLevels, 0, 1),
+      .region = vk::BufferImageCopy(
+        alloc.offset, 0, 0, subresource,
+        vk::Offset3D(0, 0, 0),
+        vk::Extent3D(width, height, 1)),
+    };
+    m_transferThread.pushJob(copyJob);
+
+    ktxTexture_Destroy(ktxTexture(kTexture));
+
+    return texture;
   }
 };
 

--- a/src/TransferThread.h
+++ b/src/TransferThread.h
@@ -1,0 +1,148 @@
+#ifndef TRANSFERTHREAD_H
+#define TRANSFERTHREAD_H
+
+#include <deque>
+#include <vulkan/vulkan.hpp>
+#include "concurrentqueue/blockingconcurrentqueue.h"
+
+#include "StagingBuffer.h"
+#include "utils.cpp"
+
+// TODO: More universal job struct to copy into buffer
+struct TextureUploadJob {
+  StagingBuffer::Allocation allocation;
+  vk::Image dstImage;
+  vk::ImageSubresourceRange subresourceRange;
+  vk::BufferImageCopy region;
+  vk::ImageLayout srcImageLayout = vk::ImageLayout::eUndefined;
+  vk::ImageLayout dstImageLayout = vk::ImageLayout::eShaderReadOnlyOptimal;
+};
+
+/**
+ * Handles asynchronous GPU uploads of staging buffer allocations to textures
+ * - Pulls completed jobs from job queues (e.g., future texture loaders)
+ * - Records copy commands into a command buffer.
+ * - Submits command buffer to a transfer-capable queue
+ * - Uses semaphore signaling to track GPU completion of each allocation
+ * - Polls staging buffer to reclaim memory after GPU finishes processing
+ */
+class TransferThread {
+public:
+  TransferThread(
+    const vk::Device device,
+    const vk::Queue transferQueue,
+    const uint32_t transferQueueFamilyIndex,
+    StagingBuffer &stagingBuffer
+  ): m_device(device), m_transferQueue(transferQueue), m_stagingBuffer(stagingBuffer), m_stop(false) {
+    ZoneScoped;
+    const auto transferPoolInfo = vk::CommandPoolCreateInfo(
+      vk::CommandPoolCreateFlagBits::eResetCommandBuffer, transferQueueFamilyIndex);
+    m_commandPool = m_device.createCommandPoolUnique(transferPoolInfo);
+    const auto transferCmdInfo = vk::CommandBufferAllocateInfo(
+      m_commandPool.get(), vk::CommandBufferLevel::ePrimary, 1);
+    m_cmdBuff = std::move(m_device.allocateCommandBuffersUnique(transferCmdInfo).front());
+    m_submitFence = m_device.createFenceUnique({});
+
+    m_thread = std::thread(&TransferThread::threadLoop, this);
+  }
+
+  ~TransferThread() {
+    m_stop = true;
+    if (m_thread.joinable())
+      m_thread.join();
+  }
+
+  TransferThread(const TransferThread &) = delete;
+
+  TransferThread &operator=(const TransferThread &) = delete;
+
+  void pushJob(const TextureUploadJob &job) {
+    ZoneScoped;
+    m_queue.enqueue(job);
+  }
+
+private:
+  vk::Device m_device;
+  vk::Queue m_transferQueue;
+  StagingBuffer &m_stagingBuffer;
+  vk::UniqueCommandPool m_commandPool;
+  vk::UniqueCommandBuffer m_cmdBuff;
+  vk::UniqueFence m_submitFence;
+
+  moodycamel::BlockingConcurrentQueue<TextureUploadJob> m_queue;
+  std::thread m_thread;
+  std::atomic_bool m_stop;
+
+  std::chrono::microseconds m_maxBatchWait = std::chrono::microseconds(2000);
+
+  void threadLoop() {
+    tracy::SetThreadName("VK Transfer Thread");
+    while (!m_stop.load()) {
+      ZoneScoped;
+
+      if (TextureUploadJob firstJob{}; m_queue.wait_dequeue_timed(firstJob, m_maxBatchWait)) {
+        std::deque<TextureUploadJob> batch;
+        batch.push_back(firstJob);
+
+        TextureUploadJob nextJob{};
+        while (m_queue.try_dequeue(nextJob)) {
+          batch.push_back(nextJob);
+        }
+
+        if (!batch.empty()) {
+          recordAndSubmitBatch(batch);
+        }
+      }
+    }
+  }
+
+  void recordAndSubmitBatch(std::deque<TextureUploadJob> &batch) {
+    ZoneScoped;
+    m_device.resetFences(*m_submitFence);
+    m_cmdBuff->reset();
+    m_cmdBuff->begin({vk::CommandBufferUsageFlagBits::eOneTimeSubmit});
+
+    for (auto &job: batch) {
+      ZoneScoped;
+      cmdTransitionImageLayout2(
+        m_cmdBuff.get(),
+        job.dstImage,
+        job.srcImageLayout,
+        vk::ImageLayout::eTransferDstOptimal,
+        job.subresourceRange
+      );
+
+      m_cmdBuff->copyBufferToImage(
+        m_stagingBuffer.getBuffer(), job.dstImage,
+        vk::ImageLayout::eTransferDstOptimal, job.region);
+
+      cmdTransitionImageLayout2(
+        m_cmdBuff.get(),
+        job.dstImage,
+        vk::ImageLayout::eTransferDstOptimal,
+        job.dstImageLayout,
+        job.subresourceRange
+      );
+    }
+
+    m_cmdBuff->end();
+
+    for (auto &job : batch) {
+      m_stagingBuffer.trackAlloc(job.allocation);
+    }
+
+    const auto cbSubmitInfo = vk::CommandBufferSubmitInfo(m_cmdBuff.get());
+    const auto sigInfo = m_stagingBuffer.makeSignalInfo();
+    const auto submit = vk::SubmitInfo2({}, {}, cbSubmitInfo, sigInfo);
+
+    m_transferQueue.submit2(submit, *m_submitFence);
+
+    auto _ = m_device.waitForFences(*m_submitFence, VK_TRUE, UINT64_MAX);
+    //const vk::SemaphoreWaitInfo waitInfo = m_stagingBuffer.makeWaitInfo();
+    //auto _ = m_device.waitSemaphores(waitInfo, UINT64_MAX);
+
+    m_stagingBuffer.pollReclaimed();
+  }
+};
+
+#endif //TRANSFERTHREAD_H

--- a/src/VkTestSiteApp.cpp
+++ b/src/VkTestSiteApp.cpp
@@ -560,6 +560,7 @@ void VkTestSiteApp::mainLoop() {
     const auto cameraPos = m_camera->getViewPos();
     ImGui::Text("Camera pos: %f %f %f", cameraPos.x, cameraPos.y, cameraPos.z);
     if (!m_modelLoaded && ImGui::Button("Load model")) {
+      ZoneScopedN("Model loading");
       auto path = tinyfd_openFileDialog("Open model file", nullptr, 0, nullptr, nullptr, 0);
       if (path != nullptr) {
         auto pathStr = std::string(path);

--- a/src/VkTestSiteApp.cpp
+++ b/src/VkTestSiteApp.cpp
@@ -101,7 +101,8 @@ void VkTestSiteApp::initVk() {
   m_stagingBuffer = std::make_unique<StagingBuffer>(m_device, m_allocator, 64 * 1024 * 1024); // 64 MB
   m_transferThread = std::make_unique<TransferThread>(m_device, m_transferQueue, indices.transfer, *m_stagingBuffer);
   m_texManager = std::make_unique<TextureManager>(
-    m_device, m_graphicsQueue, m_commandPool, m_allocator, m_geometryDescriptorSet, 1);
+    m_device, m_graphicsQueue, m_commandPool, *m_stagingBuffer, *m_transferThread, m_allocator, m_geometryDescriptorSet,
+    1);
 
   m_camera = std::make_unique<Camera>();
   auto keyCallback = [](GLFWwindow *window, int key, int scancode, int action, int mods) {

--- a/src/VkTestSiteApp.cpp
+++ b/src/VkTestSiteApp.cpp
@@ -237,14 +237,25 @@ void VkTestSiteApp::createLogicalDevice() {
   vk::PhysicalDeviceFeatures device_features{};
   vk::PhysicalDeviceDescriptorIndexingFeatures descriptor_indexing_features{};
   vk::PhysicalDeviceHostQueryResetFeatures hostQueryResetFeatures{};
+  vk::PhysicalDeviceTimelineSemaphoreFeatures timeline_semaphore_features{};
+  vk::PhysicalDeviceVulkan13Features features13{};
+
   hostQueryResetFeatures.setHostQueryReset(true);
+  timeline_semaphore_features
+      .setTimelineSemaphore(true)
+      .setPNext(&hostQueryResetFeatures);
   descriptor_indexing_features
       .setDescriptorBindingPartiallyBound(true)
       .setDescriptorBindingSampledImageUpdateAfterBind(true)
       .setShaderSampledImageArrayNonUniformIndexing(true)
       .setRuntimeDescriptorArray(true)
       .setDescriptorBindingVariableDescriptorCount(true)
-      .setPNext(&hostQueryResetFeatures);
+      .setPNext(&timeline_semaphore_features);
+
+  features13
+      .setSynchronization2(true)
+      .setPNext(&descriptor_indexing_features);
+
   device_features
       .setSamplerAnisotropy(true)
       .setSampleRateShading(true);
@@ -256,7 +267,7 @@ void VkTestSiteApp::createLogicalDevice() {
     DEVICE_EXTENSIONS,
     &device_features
   );
-  device_create_info.setPNext(&descriptor_indexing_features);
+  device_create_info.setPNext(&features13);
 
   m_device = m_physicalDevice.createDevice(device_create_info);
   VULKAN_HPP_DEFAULT_DISPATCHER.init(m_device);

--- a/src/VkTestSiteApp.cpp
+++ b/src/VkTestSiteApp.cpp
@@ -206,7 +206,7 @@ void VkTestSiteApp::createQueues() {
   const auto indices = QueueFamilyIndices(m_surface.get(), m_physicalDevice);
   m_graphicsQueue = m_device.getQueue(indices.graphics, 0);
   m_presentQueue = m_device.getQueue(indices.present, 0);
-  m_transferQueue = m_device.getQueue(indices.transfer, 0);
+  m_transferQueue = m_device.getQueue(indices.transfer, 1);
 }
 
 void VkTestSiteApp::createLogicalDevice() {
@@ -214,15 +214,23 @@ void VkTestSiteApp::createLogicalDevice() {
   auto indices = QueueFamilyIndices(m_surface.get(), m_physicalDevice);
 
   std::vector<vk::DeviceQueueCreateInfo> queue_create_infos;
+  std::vector<std::vector<float>> queuePrioritiesStorage;
   std::set queue_families = {indices.graphics, indices.present, indices.transfer};
 
-  float queuePriority = 1.0f;
   for (uint32_t queue_family: queue_families) {
+    uint32_t count = 1;
+    if (queue_family == indices.graphics && indices.graphics == indices.transfer) {
+      count = 2;
+    }
+
+    queuePrioritiesStorage.emplace_back(count, 1.0f);
+    auto& priorities = queuePrioritiesStorage.back();
+
     vk::DeviceQueueCreateInfo queue_create_info{};
     queue_create_info
         .setQueueFamilyIndex(queue_family)
-        .setQueueCount(1)
-        .setPQueuePriorities(&queuePriority);
+        .setQueueCount(count)
+        .setPQueuePriorities(priorities.data());
     queue_create_infos.push_back(queue_create_info);
   }
 

--- a/src/VkTestSiteApp.cpp
+++ b/src/VkTestSiteApp.cpp
@@ -99,6 +99,7 @@ void VkTestSiteApp::initVk() {
   createSyncObjects();
   const auto indices = QueueFamilyIndices(m_surface.get(), m_physicalDevice);
   m_stagingBuffer = std::make_unique<StagingBuffer>(m_device, m_allocator, 64 * 1024 * 1024); // 64 MB
+  m_transferThread = std::make_unique<TransferThread>(m_device, m_transferQueue, indices.transfer, *m_stagingBuffer);
   m_texManager = std::make_unique<TextureManager>(
     m_device, m_graphicsQueue, m_commandPool, m_allocator, m_geometryDescriptorSet, 1);
 
@@ -845,6 +846,7 @@ void VkTestSiteApp::cleanup() {
     m_model.reset();
   m_texManager.reset();
   m_lightManager.reset();
+  m_transferThread.reset();
   m_stagingBuffer.reset();
   m_imguiCommandBuffers.clear();
   m_lightingCommandBuffers.clear();

--- a/src/VkTestSiteApp.cpp
+++ b/src/VkTestSiteApp.cpp
@@ -596,6 +596,17 @@ void VkTestSiteApp::mainLoop() {
       m_modelLoaded = false;
     }
 
+    if (m_modelLoaded && ImGui::Button("Dump VMA stats")) {
+      char* statsString = nullptr;
+      vmaBuildStatsString(m_allocator, &statsString, true);
+      {
+        std::ofstream outStats{ "VmaStats.json" };
+        outStats << statsString;
+        spdlog::info("VMA stats json saved at VmaStats.json file");
+      }
+      vmaFreeStatsString(m_allocator, statsString);
+    }
+
     ImGui::Separator();
     ImGui::Text("Select G-Buffer Debug Output");
     ImGui::RadioButton("None", &m_debugView, 0);

--- a/src/VkTestSiteApp.cpp
+++ b/src/VkTestSiteApp.cpp
@@ -130,6 +130,8 @@ void VkTestSiteApp::initVk() {
   m_tracyCmdBuffer = m_device.allocateCommandBuffers(
     vk::CommandBufferAllocateInfo(m_commandPool, vk::CommandBufferLevel::ePrimary, 1))[0];
   m_vkContext = tracy::CreateVkContext(m_physicalDevice, m_device, m_graphicsQueue, m_tracyCmdBuffer, gpdctd, gct);
+  const std::string contextName = "Graphics Queue";
+  m_vkContext->Name(contextName.data(), contextName.size());
 #endif
 
   ImGui_ImplGlfw_InitForVulkan(m_window, true);
@@ -752,8 +754,7 @@ void VkTestSiteApp::recordCommandBuffer(ImDrawData *draw_data, const vk::Command
       vk::CommandBufferUsageFlagBits::eRenderPassContinue | vk::CommandBufferUsageFlagBits::eSimultaneousUse,
       &inheritanceInfo);
     lightCmd.reset();
-    lightCmd.begin(lightBeginInfo);
-    {
+    lightCmd.begin(lightBeginInfo); {
       TracyVkZone(m_vkContext, lightCmd, "Light Pass");
       m_swapchain.cmdSetViewport(lightCmd);
       m_swapchain.cmdSetScissor(lightCmd);
@@ -774,8 +775,7 @@ void VkTestSiteApp::recordCommandBuffer(ImDrawData *draw_data, const vk::Command
       vk::CommandBufferUsageFlagBits::eRenderPassContinue | vk::CommandBufferUsageFlagBits::eSimultaneousUse,
       &inheritanceInfo);
     imguiCmd.reset();
-    imguiCmd.begin(imguiBeginInfo);
-    {
+    imguiCmd.begin(imguiBeginInfo); {
       TracyVkZone(m_vkContext, imguiCmd, "Imgui");
       ImGui_ImplVulkan_RenderDrawData(draw_data, imguiCmd);
     }

--- a/src/VkTestSiteApp.h
+++ b/src/VkTestSiteApp.h
@@ -37,6 +37,7 @@
 #include "TextureManager.h"
 #include "Pipeline.h"
 #include "Light.h"
+#include "StagingBuffer.h"
 
 struct alignas(16) UniformBufferObject {
   glm::vec4 viewPos;
@@ -66,13 +67,11 @@ private:
   vk::Device m_device;
   vk::Queue m_graphicsQueue;
   vk::Queue m_presentQueue;
-  vk::Queue m_transferQueue;
   Swapchain m_swapchain;
   vk::RenderPass m_renderPass;
   vk::Pipeline m_geometryPipeline;
   vk::Pipeline m_lightingPipeline;
   vk::CommandPool m_commandPool;
-  vk::CommandPool m_transferCommandPool;
   DescriptorPool m_descriptorPool;
   DescriptorSet m_geometryDescriptorSet;
   DescriptorSet m_lightingDescriptorSet;
@@ -86,6 +85,8 @@ private:
   std::unique_ptr<TextureManager> m_texManager;
   std::unique_ptr<LightManager> m_lightManager;
 
+  vk::Queue m_transferQueue;
+  std::unique_ptr<StagingBuffer> m_stagingBuffer;
   std::vector<vk::Framebuffer> m_framebuffers;
   std::vector<UniformBuffer<UniformBufferObject>> m_uniforms = {};
   std::vector<vk::CommandBuffer> m_commandBuffers;

--- a/src/VkTestSiteApp.h
+++ b/src/VkTestSiteApp.h
@@ -38,6 +38,7 @@
 #include "Pipeline.h"
 #include "Light.h"
 #include "StagingBuffer.h"
+#include "TransferThread.h"
 
 struct alignas(16) UniformBufferObject {
   glm::vec4 viewPos;
@@ -86,7 +87,9 @@ private:
   std::unique_ptr<LightManager> m_lightManager;
 
   vk::Queue m_transferQueue;
+  std::unique_ptr<TransferThread> m_transferThread;
   std::unique_ptr<StagingBuffer> m_stagingBuffer;
+
   std::vector<vk::Framebuffer> m_framebuffers;
   std::vector<UniformBuffer<UniformBufferObject>> m_uniforms = {};
   std::vector<vk::CommandBuffer> m_commandBuffers;

--- a/src/VkTestSiteApp.h
+++ b/src/VkTestSiteApp.h
@@ -38,6 +38,7 @@
 #include "Pipeline.h"
 #include "Light.h"
 #include "StagingBuffer.h"
+#include "TextureWorkersPool.h"
 #include "TransferThread.h"
 
 struct alignas(16) UniformBufferObject {
@@ -89,6 +90,7 @@ private:
   vk::Queue m_transferQueue;
   std::unique_ptr<TransferThread> m_transferThread;
   std::unique_ptr<StagingBuffer> m_stagingBuffer;
+  std::unique_ptr<TextureWorkerPool> m_textureWorkerPool;
 
   std::vector<vk::Framebuffer> m_framebuffers;
   std::vector<UniformBuffer<UniformBufferObject>> m_uniforms = {};

--- a/vcpkg-overlays/ports/tracy/build-tools.patch
+++ b/vcpkg-overlays/ports/tracy/build-tools.patch
@@ -1,0 +1,38 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 72901a8c..365724a8 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -193,3 +193,15 @@ if(TRACY_CLIENT_PYTHON)
+ 
+     add_subdirectory(python)
+ endif()
++
++option(VCPKG_CLI_TOOLS "library" OFF)
++option(VCPKG_GUI_TOOLS "library" OFF)
++if(VCPKG_CLI_TOOLS)
++    add_subdirectory(csvexport)
++    add_subdirectory(capture)
++    add_subdirectory(import)
++    add_subdirectory(update)
++endif()
++if(VCPKG_GUI_TOOLS)
++    add_subdirectory(profiler)
++endif()
+diff --git a/cmake/server.cmake b/cmake/server.cmake
+index c12a3408..0d55cf91 100644
+--- a/cmake/server.cmake
++++ b/cmake/server.cmake
+@@ -1,3 +1,4 @@
++include_guard(GLOBAL)
+ set(TRACY_COMMON_DIR ${CMAKE_CURRENT_LIST_DIR}/../public/common)
+ 
+ set(TRACY_COMMON_SOURCES
+diff --git a/cmake/vendor.cmake b/cmake/vendor.cmake
+index 29f12cfa..40b3e078 100644
+--- a/cmake/vendor.cmake
++++ b/cmake/vendor.cmake
+@@ -1,3 +1,4 @@
++include_guard(GLOBAL)
+ # Vendor Specific CMake
+ # The Tracy project keeps most vendor source locally
+ 

--- a/vcpkg-overlays/ports/tracy/disable-git.patch
+++ b/vcpkg-overlays/ports/tracy/disable-git.patch
@@ -1,0 +1,13 @@
+diff --git a/profiler/CMakeLists.txt b/profiler/CMakeLists.txt
+index bd7ddc0..9fb7ac6 100644
+--- a/profiler/CMakeLists.txt
++++ b/profiler/CMakeLists.txt
+@@ -191,7 +191,7 @@ if(NOT DEFINED GIT_REV)
+ endif()
+ 
+ find_package(Git)
+-if(Git_FOUND)
++if(0)
+     add_custom_target(git-ref
+         COMMAND ${GIT_EXECUTABLE} -C ${CMAKE_CURRENT_SOURCE_DIR} log -1 "--format=#pragma once %nnamespace tracy { static inline const char* GitRef = %x22%h%x22; }" ${GIT_REV} > GitRef.hpp.tmp
+         COMMAND ${CMAKE_COMMAND} -E copy_if_different GitRef.hpp.tmp GitRef.hpp

--- a/vcpkg-overlays/ports/tracy/downgrade-capstone-5.patch
+++ b/vcpkg-overlays/ports/tracy/downgrade-capstone-5.patch
@@ -1,0 +1,74 @@
+diff --git a/profiler/src/profiler/TracySourceView.cpp b/profiler/src/profiler/TracySourceView.cpp
+index 8f4c3e1..a507baa 100644
+--- a/profiler/src/profiler/TracySourceView.cpp
++++ b/profiler/src/profiler/TracySourceView.cpp
+@@ -712,7 +712,7 @@ bool SourceView::Disassemble( uint64_t symAddr, const Worker& worker )
+         rval = cs_open( CS_ARCH_ARM, CS_MODE_ARM, &handle );
+         break;
+     case CpuArchArm64:
+-        rval = cs_open( CS_ARCH_AARCH64, CS_MODE_ARM, &handle );
++        rval = cs_open( CS_ARCH_ARM64, CS_MODE_ARM, &handle );
+         break;
+     default:
+         assert( false );
+@@ -777,9 +777,9 @@ bool SourceView::Disassemble( uint64_t symAddr, const Worker& worker )
+                     }
+                     break;
+                 case CpuArchArm64:
+-                    if( detail.aarch64.op_count == 1 && detail.aarch64.operands[0].type == AARCH64_OP_IMM )
++                    if( detail.arm64.op_count == 1 && detail.arm64.operands[0].type == ARM64_OP_IMM )
+                     {
+-                        jumpAddr = (uint64_t)detail.aarch64.operands[0].imm;
++                        jumpAddr = (uint64_t)detail.arm64.operands[0].imm;
+                     }
+                     break;
+                 default:
+@@ -864,18 +864,18 @@ bool SourceView::Disassemble( uint64_t symAddr, const Worker& worker )
+                 }
+                 break;
+             case CpuArchArm64:
+-                for( uint8_t i=0; i<detail.aarch64.op_count; i++ )
++                for( uint8_t i=0; i<detail.arm64.op_count; i++ )
+                 {
+                     uint8_t type = 0;
+-                    switch( detail.aarch64.operands[i].type )
++                    switch( detail.arm64.operands[i].type )
+                     {
+-                    case AARCH64_OP_IMM:
++                    case ARM64_OP_IMM:
+                         type = 0;
+                         break;
+-                    case AARCH64_OP_REG:
++                    case ARM64_OP_REG:
+                         type = 1;
+                         break;
+-                    case AARCH64_OP_MEM:
++                    case ARM64_OP_MEM:
+                         type = 2;
+                         break;
+                     default:
+diff --git a/server/TracyWorker.cpp b/server/TracyWorker.cpp
+index 6957531..dcc740f 100644
+--- a/server/TracyWorker.cpp
++++ b/server/TracyWorker.cpp
+@@ -3867,7 +3867,7 @@ void Worker::AddSymbolCode( uint64_t ptr, const char* data, size_t sz )
+         rval = cs_open( CS_ARCH_ARM, CS_MODE_ARM, &handle );
+         break;
+     case CpuArchArm64:
+-        rval = cs_open( CS_ARCH_AARCH64, CS_MODE_ARM, &handle );
++        rval = cs_open( CS_ARCH_ARM64, CS_MODE_ARM, &handle );
+         break;
+     default:
+         assert( false );
+@@ -3911,9 +3911,9 @@ void Worker::AddSymbolCode( uint64_t ptr, const char* data, size_t sz )
+                         }
+                         break;
+                     case CpuArchArm64:
+-                        if( detail.aarch64.op_count == 1 && detail.aarch64.operands[0].type == AARCH64_OP_IMM )
++                        if( detail.arm64.op_count == 1 && detail.arm64.operands[0].type == ARM64_OP_IMM )
+                         {
+-                            callAddr = (uint64_t)detail.aarch64.operands[0].imm;
++                            callAddr = (uint64_t)detail.arm64.operands[0].imm;
+                         }
+                         break;
+                     default:

--- a/vcpkg-overlays/ports/tracy/portfile.cmake
+++ b/vcpkg-overlays/ports/tracy/portfile.cmake
@@ -1,0 +1,69 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO wolfpld/tracy
+    REF "v${VERSION}"
+    SHA512 991ac48a00943b349b1bed9110fa7886d1378bf4e0f488b214aca244db988a9c39bfb8b4df6e60cea604fbb5d43120d6be68a0fcfbf41300547a4726a62a98d3
+    HEAD_REF master
+    PATCHES
+        build-tools.patch
+        unvendoring.patch
+        downgrade-capstone-5.patch
+        disable-git.patch
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        on-demand TRACY_ON_DEMAND
+        fibers	  TRACY_FIBERS
+        verbose   TRACY_VERBOSE
+    INVERTED_FEATURES
+        crash-handler TRACY_NO_CRASH_HANDLER
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS TOOLS_OPTIONS
+    FEATURES
+        cli-tools VCPKG_CLI_TOOLS
+        gui-tools VCPKG_GUI_TOOLS
+)
+
+if("cli-tools" IN_LIST FEATURES OR "gui-tools" IN_LIST FEATURES)
+    vcpkg_find_acquire_program(PKGCONFIG)
+    list(APPEND TOOLS_OPTIONS "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}")
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        -DDOWNLOAD_CAPSTONE=OFF
+        -DLEGACY=ON
+        ${FEATURE_OPTIONS}
+    OPTIONS_RELEASE
+        ${TOOLS_OPTIONS}
+    MAYBE_UNUSED_VARIABLES
+        DOWNLOAD_CAPSTONE
+        LEGACY
+)
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(PACKAGE_NAME Tracy CONFIG_PATH "lib/cmake/Tracy")
+
+function(tracy_copy_tool tool_name tool_dir)
+    vcpkg_copy_tools(
+        TOOL_NAMES "${tool_name}"
+        SEARCH_DIR "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/${tool_dir}"
+    )
+endfunction()
+
+if("cli-tools" IN_LIST FEATURES)
+    tracy_copy_tool(tracy-capture capture)
+    tracy_copy_tool(tracy-csvexport csvexport)
+    tracy_copy_tool(tracy-import-chrome import)
+    tracy_copy_tool(tracy-import-fuchsia import)
+    tracy_copy_tool(tracy-update update)
+endif()
+if("gui-tools" IN_LIST FEATURES)
+    tracy_copy_tool(tracy-profiler profiler)
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/vcpkg-overlays/ports/tracy/unvendoring.patch
+++ b/vcpkg-overlays/ports/tracy/unvendoring.patch
@@ -1,0 +1,95 @@
+diff --git a/cmake/server.cmake b/cmake/server.cmake
+index d736de3..ef9d35c 100644
+--- a/cmake/server.cmake
++++ b/cmake/server.cmake
+@@ -30,7 +30,7 @@ list(TRANSFORM TRACY_SERVER_SOURCES PREPEND "${TRACY_SERVER_DIR}/")
+ 
+ add_library(TracyServer STATIC EXCLUDE_FROM_ALL ${TRACY_COMMON_SOURCES} ${TRACY_SERVER_SOURCES})
+ target_include_directories(TracyServer PUBLIC ${TRACY_COMMON_DIR} ${TRACY_SERVER_DIR})
+-target_link_libraries(TracyServer PUBLIC TracyCapstone libzstd PPQSort::PPQSort)
++target_link_libraries(TracyServer PUBLIC TracyCapstone zstd::libzstd PPQSort::PPQSort)
+ if(NO_STATISTICS)
+     target_compile_definitions(TracyServer PUBLIC TRACY_NO_STATISTICS)
+ endif()
+diff --git a/cmake/vendor.cmake b/cmake/vendor.cmake
+index d310f97..e479bca 100644
+--- a/cmake/vendor.cmake
++++ b/cmake/vendor.cmake
+@@ -104,15 +104,7 @@ endif()
+ 
+ # Zstd
+ 
+-CPMAddPackage(
+-    NAME zstd
+-    GITHUB_REPOSITORY facebook/zstd
+-    GIT_TAG v1.5.7
+-    OPTIONS
+-        "ZSTD_BUILD_SHARED OFF"
+-    EXCLUDE_FROM_ALL TRUE
+-    SOURCE_SUBDIR build/cmake
+-)
++find_package(zstd CONFIG REQUIRED)
+ 
+ # Diff Template Library
+ 
+@@ -150,8 +142,12 @@ set(IMGUI_SOURCES
+     imgui_tables.cpp
+     misc/freetype/imgui_freetype.cpp
+     backends/imgui_impl_opengl3.cpp
++    backends/imgui_impl_glfw.cpp
+ )
+ 
++# Make ImGui_SOURCE_DIR available to the parent scope
++set(ImGui_SOURCE_DIR "${ImGui_SOURCE_DIR}" PARENT_SCOPE)
++
+ list(TRANSFORM IMGUI_SOURCES PREPEND "${ImGui_SOURCE_DIR}/")
+ 
+ add_library(TracyImGui STATIC EXCLUDE_FROM_ALL ${IMGUI_SOURCES})
+@@ -166,29 +162,8 @@ endif()
+ # NFD
+ 
+ if(NOT NO_FILESELECTOR AND NOT EMSCRIPTEN)
+-    if(GTK_FILESELECTOR)
+-        set(NFD_PORTAL OFF)
+-    else()
+-        set(NFD_PORTAL ON)
+-    endif()
+-
+-    CPMAddPackage(
+-        NAME nfd
+-        GITHUB_REPOSITORY btzy/nativefiledialog-extended
+-        GIT_TAG v1.2.1
+-        EXCLUDE_FROM_ALL TRUE
+-        OPTIONS
+-            "NFD_PORTAL ${NFD_PORTAL}"
+-    )
++    find_package(nfd CONFIG REQUIRED)
+ endif()
+ 
+ # PPQSort
+-
+-CPMAddPackage(
+-    NAME PPQSort
+-    GITHUB_REPOSITORY GabTux/PPQSort
+-    VERSION 1.0.5
+-    PATCHES
+-        "${CMAKE_CURRENT_LIST_DIR}/ppqsort-nodebug.patch"
+-    EXCLUDE_FROM_ALL TRUE
+-)
++find_package(PPQSort CONFIG REQUIRED)
+diff --git a/profiler/CMakeLists.txt b/profiler/CMakeLists.txt
+index bd7ddc0..0ca4359 100644
+--- a/profiler/CMakeLists.txt
++++ b/profiler/CMakeLists.txt
+@@ -26,6 +26,11 @@ include(${CMAKE_CURRENT_LIST_DIR}/../cmake/config.cmake)
+ include(${CMAKE_CURRENT_LIST_DIR}/../cmake/vendor.cmake)
+ include(${CMAKE_CURRENT_LIST_DIR}/../cmake/server.cmake)
+ 
++# FIXME: this is a workaround for cmake failing to find nfd which is enabled in vendor.cmake
++if(NOT NO_FILESELECTOR AND NOT EMSCRIPTEN)
++    find_package(nfd CONFIG REQUIRED)
++endif()
++
+ set(SERVER_FILES
+     TracyAchievementData.cpp
+     TracyAchievements.cpp

--- a/vcpkg-overlays/ports/tracy/vcpkg.json
+++ b/vcpkg-overlays/ports/tracy/vcpkg.json
@@ -1,0 +1,85 @@
+{
+  "name": "tracy",
+  "version": "0.12.1",
+  "description": "A real time, nanosecond resolution, remote telemetry, hybrid frame and sampling profiler for games and other applications.",
+  "homepage": "https://github.com/wolfpld/tracy",
+  "license": "BSD-3-Clause",
+  "supports": "!(windows & (arm | uwp))",
+  "dependencies": [
+    {
+      "name": "pthreads",
+      "platform": "!windows"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    "zstd"
+  ],
+  "default-features": [
+    "crash-handler"
+  ],
+  "features": {
+    "cli-tools": {
+      "description": "Build Tracy command-line tools: `capture`, `csvexport`, `import-chrome`, `import-fuchsia` and `update`",
+      "supports": "!(windows & x86)",
+      "dependencies": [
+        {
+          "name": "capstone",
+          "features": [
+            "arm",
+            "arm64",
+            "x86"
+          ]
+        },
+        {
+          "name": "dbus",
+          "default-features": false,
+          "platform": "!windows"
+        },
+        "freetype",
+        "glfw3",
+        "ppqsort"
+      ]
+    },
+    "crash-handler": {
+      "description": "Enable crash handler"
+    },
+    "fibers": {
+      "description": "Enable fibers support"
+    },
+    "gui-tools": {
+      "description": "Build Tracy GUI tool: `profiler` (aka `Tracy` executable)",
+      "supports": "!(windows & x86)",
+      "dependencies": [
+        {
+          "name": "capstone",
+          "features": [
+            "arm",
+            "arm64",
+            "x86"
+          ]
+        },
+        {
+          "name": "dbus",
+          "default-features": false,
+          "platform": "!windows"
+        },
+        "freetype",
+        "glfw3",
+        "nativefiledialog-extended",
+        "ppqsort"
+      ]
+    },
+    "on-demand": {
+      "description": "Enable on-demand profiling"
+    },
+    "verbose": {
+      "description": "Enables verbose logging"
+    }
+  }
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -20,6 +20,7 @@
     "tinyfiledialogs",
     "stb",
     "fmt",
+    "concurrentqueue",
     "spdlog",
   ],
   "overrides": [

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -22,6 +22,12 @@
     "fmt",
     "concurrentqueue",
     "spdlog",
+    {
+      "name": "ktx",
+      "features": [
+        "vulkan"
+      ]
+    }
   ],
   "overrides": [
     {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -30,6 +30,10 @@
     {
       "name": "fmt",
       "version": "11.2.0"
+    },
+    {
+      "name": "tracy",
+      "version": "0.12.1"
     }
   ]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -41,6 +41,10 @@
     {
       "name": "tracy",
       "version": "0.12.1"
+    },
+    {
+      "name": "assimp",
+      "version": "6.0.2"
     }
   ]
 }


### PR DESCRIPTION
# Asynchronous Texture Loading System
Previously, models and their material texture were loading entirely on the main thread, causing freezing render cycle until loading completed. 
This change one of several steps to resolve this. It introduces a new asynchronous texture loading pipeline and adds support for KTX/KTX2 textures.

## Overview
New core components:
* **Staging Buffer** - a ring-style host-visible staging buffer used to temporarily store texture data before GPU upload.
* **Transfer Thread** - a dedicated thread that uploading data from the staging buffer to VRAM using a separated transfer queue, supporting batching for efficiency.
* **Texture Workers Pool** - a pool of workers threads for loading, transcoding, and preparing texture data for upload.

## New texture loading pipeline
1. A ```TextureLoadJob``` is enqueued into the **Texture Workers Pool** queue.
2. A free worker dequeues a job and loading the texture (general formats by stb_image, KTX/KTX2 via libktx).
3. After loading, the worker allocates space in the **Staging Buffer** and copies the texture data into it.
4. Then worker then submits a  ```TextureUploadJob``` to the **Transfer Thread** queue.
5. The **Transfer Thread** dequeue jobs and batching multiple uploads where possible.
6. For each batch, the thread record and submit copy command to the Vulkan transfer queue.
7. Once the GPU transfer completes, the **Staging Buffer** free its allocations, and the **Texture Workers Pool** pushes ```TextureLoadDone``` with ```Texture``` object into done queue.
